### PR TITLE
Initialize $active in Pool#wait()

### DIFF
--- a/src/Internal/Pool.php
+++ b/src/Internal/Pool.php
@@ -78,6 +78,7 @@ class Pool
      */
     public function wait()
     {
+        $active = 0;
         curl_multi_exec($this->mh, $active); // Start requests.
         do {
             // if cURL handle is running, use curl_multi_select()


### PR DESCRIPTION
With [php-vcr](https://github.com/php-vcr/php-vcr), `Undefined variable $active` occurs as php-vcr replaces curl function with its own wrapper function.